### PR TITLE
Workflows: Use Latest Runtime

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Installing .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.100-preview.3.22179.4
+        dotnet-version: 7.0.x
         include-prerelease: true
     - name: Restoring NuGet Packages
       run: dotnet restore


### PR DESCRIPTION
This way you will not worry about build numbers when new previews comes out